### PR TITLE
add getProcessPidStats getProcessCgroupSched implement

### DIFF
--- a/process_stats.go
+++ b/process_stats.go
@@ -1,12 +1,91 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
+	"syscall"
+	"unsafe"
 
 	pb "github.com/kata-containers/agent/protocols/grpc"
+	"github.com/sirupsen/logrus"
 )
+
+const (
+	PidIO   = "/proc/%d/io"
+	PidFd   = "/proc/%d/fd/"
+	PidStat = "/proc/%d/stat"
+
+	PidCgroup  = "/proc/%d/cgroup"
+	CfsBaseDir = "/sys/fs/cgroup"
+	CfsStatics = "cpuacct.sched_cfs_statistics"
+
+	ReadSysFsBufSize  = 1024 * 512
+	ReadDirentBufSize = 4096 * 25
+)
+
+// struct for /proc/{pid}/stat
+type ProcStat struct {
+	PID        int
+	TaskName   string
+	State      string
+	PPID       int
+	PGID       int
+	SID        int
+	TtyNr      int
+	TtyPgrp    int
+	TaskFlags  uint
+	MinFlt     uint
+	CMinFlt    uint
+	MajFlt     uint
+	CMajFlt    uint
+	UTime      uint
+	STime      uint
+	CUTime     uint
+	CSTime     uint
+	Priority   int
+	Nice       int
+	NumThreads int
+	StartTime  uint64
+	VSize      uint
+	MMRss      int
+}
+
+// struct for /proc/{pid}/io
+type ProcIO struct {
+	RChar               uint64 `json:"rchar"`
+	WChar               uint64 `json:"wchar"`
+	SyscR               uint64 `json:"syscr"`
+	SyscW               uint64 `json:"syscw"`
+	ReadBytes           uint64 `json:"read_bytes"`
+	WriteBytes          uint64 `json:"write_bytes"`
+	CancelledWriteBytes int64  `json:"cancelled_write_bytes"`
+}
+
+// struct for /sys/fs/cgroup/cpu/.../cpuacct.sched_cfs_statistics
+type CgroupSchedLine2 struct {
+	BvtDelay       uint64
+	NoiseKickDelay uint64
+	LossTime       uint64
+}
+type CgroupSchedLine4 struct {
+	TasksDelayMs0  uint64
+	TasksDelayMs1  uint64
+	TasksDelayMs2  uint64
+	TasksDelayMs3  uint64
+	TasksDelayMs4  uint64
+	TasksDelayMs5  uint64
+	TasksDelayMs6  uint64
+	TasksDelayMs7  uint64
+	TasksDelayMs8  uint64
+	TasksDelayMs9  uint64
+	TasksDelayMs10 uint64
+	TasksDelayMs11 uint64
+}
 
 func getProcessProcCpuStats(Pid int) (*pb.ProcessProcCpuStats, error) {
 	strLines, err := GetFileContent1MBAsStringLines(fmt.Sprintf("/proc/%d/stat", Pid))
@@ -162,4 +241,270 @@ func getProcessProcMemStats(Pid int) (*pb.ProcessProcMemStats, error) {
 	}
 
 	return ppms, err
+}
+
+func getProcessPidStats(pid int) (*pb.ProcessPidStats, error) {
+	// read /proc/{pid}/stat
+	ps, err := readProcStat(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read proc stat of pid %d, error:%v", pid, err)
+	}
+
+	// read /proc/{pid}/id
+	pio, err := readProcIO(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read proc io of pid %d, error:%v", pid, err)
+	}
+
+	// calculate fd count
+	fdCnt, _ := calcProcFdCount(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fd count of pid %d, error:%v", pid, err)
+	}
+
+	return &pb.ProcessPidStats{
+		UserCpu:    uint64(ps.UTime + ps.CUTime),
+		SysCpu:     uint64(ps.STime + ps.CSTime),
+		Mem:        uint64(ps.MMRss * 4096),
+		ReadBytes:  pio.ReadBytes,
+		WriteBytes: pio.WriteBytes,
+		Fdcnt:      uint64(fdCnt),
+		Minflt:     uint64(ps.MinFlt),
+		Majflt:     uint64(ps.MajFlt),
+		Thread:     uint64(ps.NumThreads),
+	}, nil
+}
+
+func getProcessCgroupSched(pid int) (*pb.ProcessCgroupSched, error) {
+	cgPath, err := getCgroupPathFromPid(pid, "cpuacct")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cgroup path from pid %d, error:%v", pid, err)
+	}
+
+	CCfsPath := fmt.Sprintf("%s/cpu%s/%s", CfsBaseDir, cgPath, CfsStatics)
+
+	if _, err := os.Stat(CCfsPath); err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warnf("cgroup sched stat file %s not found", CCfsPath)
+			return &pb.ProcessCgroupSched{}, nil
+		} else {
+			return nil, fmt.Errorf("failed to read cgroup sched stat file %s, error:%v", CCfsPath, err)
+		}
+	}
+
+	line2, line4, err := readCGroupSchedCfsStat(CCfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.ProcessCgroupSched{
+		BvtDelay:       line2.BvtDelay,
+		NoiseKickDelay: line2.NoiseKickDelay,
+		LossTime:       line2.LossTime,
+		TasksDelayMs: []uint64{
+			line4.TasksDelayMs0,
+			line4.TasksDelayMs1,
+			line4.TasksDelayMs2,
+			line4.TasksDelayMs3,
+			line4.TasksDelayMs4,
+			line4.TasksDelayMs5,
+			line4.TasksDelayMs6,
+			line4.TasksDelayMs7,
+			line4.TasksDelayMs8,
+			line4.TasksDelayMs9,
+			line4.TasksDelayMs10,
+			line4.TasksDelayMs11,
+		},
+	}, nil
+}
+
+////////////////////////////////////////////////////////////////
+// utilities
+////////////////////////////////////////////////////////////////
+func readProcStat(pid int) (*ProcStat, error) {
+	data, err := readSysFile(fmt.Sprintf(PidStat, pid))
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		ignore int
+
+		ps = ProcStat{PID: pid}
+		l  = bytes.Index(data, []byte("("))
+		r  = bytes.LastIndex(data, []byte(")"))
+	)
+
+	if l < 0 || r < 0 {
+		return &ps, fmt.Errorf("unexpected format, couldn't extract comm: %s", data)
+	}
+
+	ps.TaskName = string(data[l+1 : r])
+	_, err = fmt.Fscan(
+		bytes.NewBuffer(data[r+2:]),
+		&ps.State,
+		&ps.PPID,
+		&ps.PGID,
+		&ps.SID,
+		&ps.TtyNr,
+		&ps.TtyPgrp,
+		&ps.TaskFlags,
+		&ps.MinFlt,
+		&ps.CMinFlt,
+		&ps.MajFlt,
+		&ps.CMajFlt,
+		&ps.UTime,
+		&ps.STime,
+		&ps.CUTime,
+		&ps.CSTime,
+		&ps.Priority,
+		&ps.Nice,
+		&ps.NumThreads,
+		&ignore,
+		&ps.StartTime,
+		&ps.VSize,
+		&ps.MMRss,
+	)
+	if err != nil {
+		return &ps, err
+	}
+
+	return &ps, nil
+}
+
+func readProcIO(pid int) (*ProcIO, error) {
+	pio := ProcIO{}
+
+	data, err := readSysFile(fmt.Sprintf(PidIO, pid))
+	if err != nil {
+		return &pio, err
+	}
+
+	format := "rchar: %d\nwchar: %d\nsyscr: %d\nsyscw: %d\nread_bytes: %d\nwrite_bytes: %d\ncancelled_write_bytes: %d\n"
+	_, err = fmt.Sscanf(string(data), format,
+		&pio.RChar, &pio.WChar, &pio.SyscR, &pio.SyscW, &pio.ReadBytes, &pio.WriteBytes, &pio.CancelledWriteBytes)
+
+	return &pio, err
+}
+
+func readCGroupSchedCfsStat(path string) (*CgroupSchedLine2, *CgroupSchedLine4, error) {
+	line2 := &CgroupSchedLine2{}
+	line4 := &CgroupSchedLine4{}
+
+	data, err := readSysFile(path)
+	if err != nil {
+		return line2, line4, err
+	}
+
+	var ignore int
+	for i, line := range strings.Split(string(data), "\n") {
+		if i == 1 {
+			//parse line2
+			_, err = fmt.Fscan(
+				bytes.NewBuffer([]byte(line)),
+				&line2.BvtDelay,
+				&line2.NoiseKickDelay,
+				&line2.LossTime,
+				&ignore,
+			)
+		} else if i == 3 {
+			//parse line4
+			_, err = fmt.Fscan(
+				bytes.NewBuffer([]byte(line)),
+				&line4.TasksDelayMs0,
+				&line4.TasksDelayMs1,
+				&line4.TasksDelayMs2,
+				&line4.TasksDelayMs3,
+				&line4.TasksDelayMs4,
+				&line4.TasksDelayMs5,
+				&line4.TasksDelayMs6,
+				&line4.TasksDelayMs7,
+				&line4.TasksDelayMs8,
+				&line4.TasksDelayMs9,
+				&line4.TasksDelayMs10,
+				&line4.TasksDelayMs11,
+			)
+		}
+	}
+	return line2, line4, nil
+}
+
+func readSysFile(filename string) ([]byte, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		logrus.Errorf("failed to read sysfs %s, error:%v", filename, err)
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := io.LimitReader(f, ReadSysFsBufSize)
+	return ioutil.ReadAll(reader)
+}
+
+func calcProcFdCount(pid int) (int, error) {
+	buf := make([]byte, ReadDirentBufSize)
+	dirPath := fmt.Sprintf(PidFd, pid)
+	d, err := os.Open(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return -1, err
+		}
+		if strings.Contains(err.Error(), "not a directory") {
+			return -1, err
+		}
+		return -1, err
+	}
+	defer d.Close()
+
+	fd := int(d.Fd())
+	fdCnt := 0
+	for {
+		nbuf, err := syscall.ReadDirent(fd, buf)
+		if err != nil {
+			return -1, err
+		}
+		if nbuf <= 0 {
+			break
+		}
+
+		for off := 0; off < nbuf; {
+			dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[off]))
+			off += int(dirent.Reclen)
+			if dirent.Type == syscall.DT_LNK {
+				fdCnt++
+			}
+		}
+	}
+
+	return fdCnt, nil
+}
+
+func getCgroupPathFromPid(pid int, controller string) (string, error) {
+	data, err := readSysFile(fmt.Sprintf(PidCgroup, pid))
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		cols := strings.Split(line, ":")
+		if len(cols) != 3 {
+			continue
+		}
+		if !strings.Contains(cols[1], controller) {
+			continue
+		}
+		return cols[2], nil
+	}
+	return "", fmt.Errorf("no cgroup path found")
+}
+
+func getContainerIdFromPid(pid int) (string, error) {
+	cgPath, err := getCgroupPathFromPid(pid, "freezer")
+	if err != nil {
+		return "", err
+	}
+
+	buf := strings.Split(cgPath, "/")
+	return buf[len(buf)-1], nil
 }

--- a/process_stats_test.go
+++ b/process_stats_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const CMD = "docker"
+
+var pid int
+
+type ContainerInspect struct {
+	State ContainerState
+}
+type ContainerState struct {
+	Pid int
+}
+
+// setup
+func setup() (int, string, error) {
+	fmt.Printf("> prepare container\n")
+
+	// run container
+	cmd := exec.Command(CMD, "run", "-d", "busybox", "top", "-b")
+	cidBuf, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("failed to run %s container, error:%v", CMD, err)
+	}
+	cid := strings.Split(string(cidBuf), "\n")[0]
+
+	// inspect container
+	cmdStr := fmt.Sprintf(`%s inspect %s`, CMD, cid)
+	cmd = exec.Command("sh", "-c", cmdStr)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Fatalf("failed to inspect container %s, error:%v", cid, err)
+	} else {
+		// get Pid
+		var inspect []ContainerInspect
+		err := json.Unmarshal(out, &inspect)
+		if err != nil {
+			log.Fatalf("failed to parse container inspect, error:%v", err)
+		}
+		if len(inspect) == 0 {
+			log.Fatalf("failed to find container %s", cid)
+		}
+		fmt.Printf("Pid of container %s is %d\n\n", string(cid), inspect[0].State.Pid)
+		return inspect[0].State.Pid, string(cid), nil
+	}
+	return -1, "", fmt.Errorf("failed to prepare container")
+}
+
+// teardown
+func tearDown(cid string) {
+	fmt.Printf("> clean container %s\n", cid)
+	cmd := exec.Command("docker", "rm", "-fv", cid)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("failed to clean container %s, error:%v", cid, err)
+	}
+	log.Printf("> clean container %s ok\n", cid)
+}
+
+// main
+func TestMain(m *testing.M) {
+	var (
+		err error
+		cid string
+	)
+	pid, cid, err = setup()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tearDown(cid)
+
+	m.Run()
+}
+
+//////////////////////////////////
+// test cases
+//////////////////////////////////
+func TestProcessGetPidStats(t *testing.T) {
+	showProcFile()
+	rlt, _ := getProcessPidStats(pid)
+	fmt.Printf("ProcessPidStats : %v\n", toJson(rlt))
+}
+
+func TestProcessGetCgroupSched(t *testing.T) {
+	rlt, _ := getProcessCgroupSched(pid)
+	fmt.Printf("ProcessCgroupSched : %v\n", toJson(rlt))
+}
+
+//////////////////////////////////
+// utilities
+//////////////////////////////////
+func showProcFile() {
+	// show proc/{pid}/stat
+	pidStat := fmt.Sprintf(PidStat, pid)
+	buf, err := readSysFile(pidStat)
+	if err != nil {
+		log.Fatalf("failed to read %s", pidStat)
+	}
+	fmt.Printf("[%s]\n%s\n", pidStat, buf)
+
+	// show proc/{pid}/ioo
+	pidIO := fmt.Sprintf(PidIO, pid)
+	buf, err = readSysFile(pidIO)
+	if err != nil {
+		log.Fatalf("failed to read %s", pidStat)
+	}
+	fmt.Printf("[%s]\n%s\n", pidIO, buf)
+}
+
+func toJson(data interface{}) string {
+	buf, _ := json.MarshalIndent(data, "", " ")
+	return string(buf)
+}


### PR DESCRIPTION
单元测试
```
$ go test -test.run TestProcessGetPidStats
ProcessPidStats : {
 "user_cpu": 1214873,
 "sys_cpu": 274434,
 "mem": 4923392,
 "read_bytes": 5244023296,
 "write_bytes": 42496430080,
 "fdcnt": 61,
 "minflt": 25481,
 "majflt": 68,
 "thread": 1
}
PASS
ok  	github.com/kata-containers/agent	0.006s
```

对照c实现
```
$ gcc -o mod_pid  mod_pid.c
$ sudo ./mod_pid
get pid by pid name: pid=1
split pidof into array pid
pid: 1
get all pid's info
read values from /proc/1/stat
strcpy_safe container_id
filename: /proc/1/stat
line: 1 (systemd) S 0 1 1 0 -1 4194560 25490 771201952 68 4224 580 1926 1214296 272521 20 0 1 0 38 128565248 1202 18446744073709551615 94272355037184 94272356479146 140736570622832 0 0 0 671173123 4096 1260 1 0 0 17 0 0 0 7 0 0 94272358576536 94272358721080 942
get io info from /proc/1/io
get_fd_count: root=/proc/1/fd/
get_fd_count: total=61
store data to asar
receive: root_1=1214876,274447,4923392,1,5244023296,42496430080,61,25490,68;
```